### PR TITLE
Fix language switch not responding

### DIFF
--- a/config/i18n.js
+++ b/config/i18n.js
@@ -682,9 +682,12 @@ class I18nManager {
      * 获取翻译文本
      */
     t(key, params = {}) {
-        const translation = this.translations[this.currentLanguage]?.[key] || 
-                          this.translations['zh-CN']?.[key] || 
-                          key;
+        let translation = key;
+        if (this.translations[this.currentLanguage] && this.translations[this.currentLanguage][key]) {
+            translation = this.translations[this.currentLanguage][key];
+        } else if (this.translations['zh-CN'] && this.translations['zh-CN'][key]) {
+            translation = this.translations['zh-CN'][key];
+        }
         
         // 支持参数替换
         
@@ -972,13 +975,15 @@ class I18nManager {
         });
 
         // 更新页面标题
-        const titleKey = document.querySelector('meta[name="title-key"]')?.content;
+        const titleMeta = document.querySelector('meta[name="title-key"]');
+        const titleKey = titleMeta ? titleMeta.content : null;
         if (titleKey) {
             document.title = this.t(titleKey);
         }
 
         // 更新meta描述
-        const descKey = document.querySelector('meta[name="desc-key"]')?.content;
+        const descMeta = document.querySelector('meta[name="desc-key"]');
+        const descKey = descMeta ? descMeta.content : null;
         if (descKey) {
             const metaDesc = document.querySelector('meta[name="description"]');
             if (metaDesc) {

--- a/js/app.js
+++ b/js/app.js
@@ -1715,7 +1715,10 @@ function initChatFeature() {
         }
         
         // 获取当前会话ID
-        const currentSessionId = window.chatSessionManager?.currentSessionId || 'new-chat';
+        let currentSessionId = 'new-chat';
+        if (window.chatSessionManager && window.chatSessionManager.currentSessionId) {
+            currentSessionId = window.chatSessionManager.currentSessionId;
+        }
         console.log('Current session ID:', currentSessionId);
         
         // 如果是"新对话"，自动创建新会话
@@ -1963,7 +1966,10 @@ function generateAIReply(userMessage) {
                 }
                 
                 // 如果没有正确格式的响应，返回原始文本
-                return response.suggestions?.[0]?.reply || response.toString();
+                if (response.suggestions && response.suggestions.length > 0 && response.suggestions[0].reply) {
+                    return response.suggestions[0].reply;
+                }
+                return response.toString();
             }
         } catch (error) {
             console.error('AI回复生成错误:', error);


### PR DESCRIPTION
## Summary
- avoid optional chaining so scripts load on older browsers
- use defensive checks when retrieving meta tags
- avoid optional chaining in chat session and AI reply logic

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685035dc36d083289eb80e1164159e0b